### PR TITLE
Turn off console logging for newer JSCover

### DIFF
--- a/bin/logging.properties
+++ b/bin/logging.properties
@@ -1,0 +1,2 @@
+handlers = java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.level = SEVERE

--- a/lib/jscover.js
+++ b/lib/jscover.js
@@ -18,8 +18,13 @@ var fse = require('fs-extra');
 var fs = require('fs');
 
 var root = path.dirname(__dirname);
-var JSCoverPath = path.join(root, 'bin', 'JSCover-all.jar');
-var JSCoverCommand = 'java -Dfile.encoding=UTF-8 -jar "' + JSCoverPath + '" -fs';
+var JSCoverPath = process.env.JSCOVER || path.join(root, 'bin', 'JSCover-all.jar');
+var JSCoverLogging = path.join(root, 'bin', 'logging.properties');
+var JSCoverCommand = ['java',
+  '-Dfile.encoding=UTF-8',
+  '-Djava.util.logging.config.file="' + JSCoverLogging + '"',
+  '-jar "' + JSCoverPath + '"',
+  '-fs'].join(' ');
 
 /**
  * Pedding codes to support nodejs

--- a/test/jscover.test.js
+++ b/test/jscover.test.js
@@ -73,7 +73,7 @@ describe('jscover.test.js', function () {
         should.not.exist(err);
         should.not.exist(output);
         var regexp = fs.readFileSync(path.join(source, 'regexp.js'), 'utf8');
-        fs.readFileSync(path.join(target, 'regexp.js'), 'utf8').should.include(regexp);
+        fs.readFileSync(path.join(target, 'regexp.js'), 'utf8').should.containEql(regexp);
         var targetFoo = require(path.join(target, 'subdir', 'foo'));
         var sourceFoo = require(path.join(source, 'subdir', 'foo'));
         for (var k in sourceFoo) {

--- a/test/jscover.test.js
+++ b/test/jscover.test.js
@@ -52,7 +52,7 @@ describe('jscover.test.js', function () {
     jscover('', null, {}, function (err) {
       should.exist(err);
       err.name.should.equal('JSCoverError');
-      err.message.trim().should.equal("Command failed: Source directory '' is invalid");
+      err.message.trim().should.endWith("Source directory '' is invalid");
       done();
     });
   });
@@ -61,7 +61,7 @@ describe('jscover.test.js', function () {
     jscover('a', 'b', {}, function (err) {
       should.exist(err);
       err.name.should.equal('JSCoverError');
-      err.message.trim().should.equal("Command failed: Source directory 'a' is invalid");
+      err.message.trim().should.endWith("Source directory 'a' is invalid");
       done();
     });
   });


### PR DESCRIPTION
Let the user override JSCover jar path by
setting JSCOVER environment variable.

JSCover since efaf49e63da243a8e6a0a0e5fe8b009161f26e42
uses Java logging facility that generates output
to stdout - this breaks node-jscover.

Provide Java logging configuration file to
stop logging to the console.
