### PR TITLE
Update dependency fs-extra to version ^1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: node_js
 node_js:
-  - 0.8
+  - "0.12"
+  - "4"
+  - "6"
+  - "7"
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
   "name": "jscover",
   "version": "1.0.0",
+  "engine": {
+    "node": "^0.12.0",
+    "node": "^4.0.0",
+    "node": "^6.0.0",
+    "node": "^7.0.0"
+  },
   "description": "node wrap for JSCover.",
   "main": "index.js",
   "directories": {
@@ -13,7 +19,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "fs-extra": "1.0.0",
+    "fs-extra": "^1.0.0",
     "debug": "0.7.0",
     "ndir": "0.1.5"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "fs-extra": "0.3.1",
+    "fs-extra": "1.0.0",
     "debug": "0.7.0",
     "ndir": "0.1.5"
   },


### PR DESCRIPTION
fs-extra@0.3.1 uses graceful-fs@1.1.14 and according to npm:
>npm WARN deprecated graceful-fs@1.1.14: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible.
fs-extra is at version 1.0.0 and using graceful-fs@^4.1.2

All tests pass with fs-extra@^1.0.0
Travis would not pass with Node.js@0.8.x engine. Updated the package.json and .travis.yml to reflect the currently supported Node.js versions.