### PR TITLE
Use modern versions of node_js runtime on TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
+  - node
+  - lts/*


### PR DESCRIPTION
Use of modern language features is breaking the ancient Node.js runtimes on CI, but it can be fixed.